### PR TITLE
Usability impovements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 local-*
 /target
 Cargo.lock
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ blocking = ["reqwest/blocking"]
 
 [dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread",] }
-parquet = "14.0.0"
-reqwest = { version = "0.11", features = ["json"] }
+parquet = "52.1.0"
+reqwest = { version = "0.12", features = ["json"] }
 url = "2.2"
 rustc_version_runtime = "0.1"
 serde = { version = "1.0", features = ["derive"] }
@@ -32,7 +32,7 @@ serde_json = "1.0"
 anyhow = "1.0"
 log = "0.4"
 env_logger = "0.9"
-polars = { version = "0.22.8", features = ["lazy", "parquet"] }
+polars = { version = "0.41.3", features = ["lazy", "parquet"] }
 
 [dev-dependencies]
 wiremock = "0.5"

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -42,7 +42,7 @@ async fn main() {
             );
         } else {
             let res = app
-                .get_dataframe(&tables[0])
+                .get_dataframe(&tables[0], None)
                 .await
                 .unwrap()
                 .collect()

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -11,7 +11,7 @@ async fn main() {
 
     let conf_str = &fs::read_to_string("./config.json").unwrap();
     let config: ProviderConfig = serde_json::from_str(conf_str).expect("Invalid configuration");
-    let mut app = Client::new(config, None).await.unwrap();
+    let mut app = Client::new(config, None, None).await.unwrap();
     let shares = app.list_shares().await.unwrap();
     if shares.len() == 0 {
         println!("At least 1 Delta Share is required");

--- a/examples/blocking.rs
+++ b/examples/blocking.rs
@@ -10,7 +10,7 @@ fn main() {
     let conf_str = &fs::read_to_string("./config.json").unwrap();
 
     let config: ProviderConfig = serde_json::from_str(conf_str).expect("Invalid configuration");
-    let mut app = Client::new(config, None).unwrap();
+    let mut app = Client::new(config, None, None).unwrap();
     let shares = app.list_shares().unwrap();
     if shares.len() == 0 {
         println!("At least 1 Delta Share is required");

--- a/examples/blocking.rs
+++ b/examples/blocking.rs
@@ -22,7 +22,7 @@ fn main() {
                 shares[0].name
             );
         } else {
-            let res = app.get_dataframe(&tables[0]).unwrap().collect().unwrap();
+            let res = app.get_dataframe(&tables[0], None).unwrap().collect().unwrap();
             println!("Dataframe:\n {}", res);
         }
     }

--- a/examples/blocking.rs
+++ b/examples/blocking.rs
@@ -22,7 +22,11 @@ fn main() {
                 shares[0].name
             );
         } else {
-            let res = app.get_dataframe(&tables[0], None).unwrap().collect().unwrap();
+            let res = app
+                .get_dataframe(&tables[0], None)
+                .unwrap()
+                .collect()
+                .unwrap();
             println!("Dataframe:\n {}", res);
         }
     }

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -261,9 +261,22 @@ impl Client {
         fs::create_dir_all(&table_path).map_err(|e| anyhow::anyhow!("Error creating table path: {e}"))?;
         let mut file_paths: Vec<PathBuf> = Vec::new();
         for file in table_files.files.clone() {
-            let dst_path = &table_path.join(format!("{}.snappy.parquet", &file.id));
-            let _ = self.download(file.url, &dst_path);
-            file_paths.push(dst_path.clone());
+            match file {
+                File::Parquet(ParquetFile { id, url, .. }) => {
+                    let dst_path = &table_path.join(format!("{}.snappy.parquet", &id));
+                    let bytes = self.download(url, &dst_path)?;
+                    debug!("Downloaded {} ({} bytes)", dst_path.display(), bytes);
+                    file_paths.push(dst_path.clone());
+                },
+                File::Delta( DeltaFile { id, url, ..}) => {
+                    if let Some(url) = url {
+                        let dst_path = &table_path.join(format!("{}.snappy.parquet", &id));
+                        let bytes = self.download(url, &dst_path)?;
+                        debug!("Downloaded {} ({} bytes)", dst_path.display(), bytes);
+                        file_paths.push(dst_path.clone());
+                    }
+                }, 
+            }
         }
         Ok(file_paths.clone())
     }
@@ -283,7 +296,11 @@ impl Client {
             if !download {
                 let mut file_paths: Vec<PathBuf> = Vec::new();
                 for file in &table_files.files {
-                    let file_path = &table_path.join(format!("{}.snappy.parquet", &file.id));
+                    let file_id = match file {
+                        File::Parquet(ParquetFile { id, ..}) => id,
+                        File::Delta(DeltaFile { id, .. }) => id
+                    };
+                    let file_path = &table_path.join(format!("{}.snappy.parquet", &file_id));
                     if !Path::exists(&file_path) {
                         // File is missing, invalidate cache
                         download = true;

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -304,7 +304,7 @@ impl Client {
                     if !Path::exists(&file_path) {
                         // File is missing, invalidate cache
                         download = true;
-                        fs::remove_dir(&table_path).map_err(|e| anyhow::anyhow!("Error invalidating cache: {e}"))?;
+                        fs::remove_dir_all(&table_path).map_err(|e| anyhow::anyhow!("Error invalidating cache: {e}"))?;
                         break;
                     }
                     file_paths.push(file_path.clone());

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -30,7 +30,7 @@ impl Client {
     pub fn new(
         provider_config: ProviderConfig,
         data_root: Option<String>,
-        capabilities: Option<HashMap<String, String>>
+        capabilities: Option<HashMap<String, String>>,
     ) -> Result<Self, anyhow::Error> {
         if provider_config.share_credentials_version > CREDENTIALS_VERSION {
             return Err(anyhow::anyhow!("'share_credentials_version' in the provider configuration is {}, which is newer than the \
@@ -54,7 +54,10 @@ impl Client {
         })
     }
 
-    fn get_client(config: &ProviderConfig, capabilities: HashMap<String, String>) -> Result<reqwest::blocking::Client, anyhow::Error> {
+    fn get_client(
+        config: &ProviderConfig,
+        capabilities: HashMap<String, String>,
+    ) -> Result<reqwest::blocking::Client, anyhow::Error> {
         let rust_version: &str = &format!("{}", rustc_version_runtime::version());
         let user_agent: &str = &format!("Delta-Sharing-Rust/{VERSION} Rust/{rust_version}");
         let bearer_token = &format!("Bearer {}", config.bearer_token);
@@ -69,10 +72,16 @@ impl Client {
             header::HeaderValue::from_str(user_agent)
                 .map_err(|e| anyhow::anyhow!("Error setting user agent header:{e}"))?,
         );
- 	headers.insert(
+        headers.insert(
             header::HeaderName::from_static("delta-sharing-capabilities"),
-            header::HeaderValue::from_str(&capabilities.iter().map(|(k,v)| format!("{k}={v}")).collect::<Vec<String>>().join(";"))
-                .map_err(|e| anyhow::anyhow!("Error setting delta-sharing-capabilities header:{e}"))?,
+            header::HeaderValue::from_str(
+                &capabilities
+                    .iter()
+                    .map(|(k, v)| format!("{k}={v}"))
+                    .collect::<Vec<String>>()
+                    .join(";"),
+            )
+            .map_err(|e| anyhow::anyhow!("Error setting delta-sharing-capabilities header:{e}"))?,
         );
         reqwest::blocking::Client::builder()
             .default_headers(headers)
@@ -87,8 +96,10 @@ impl Client {
     }
 
     fn get(&self, target: &str) -> Result<String, anyhow::Error> {
-        let url = self.base_url.join(target)
-	    .map_err(|e| anyhow::anyhow!("Error creating GET url: {e}"))?;
+        let url = self
+            .base_url
+            .join(target)
+            .map_err(|e| anyhow::anyhow!("Error creating GET url: {e}"))?;
         debug!("--> HTTP GET to: {}", &url);
         let resp = self.http_client.get(url.as_str()).send()?;
         let resp_text = resp.text()?;
@@ -97,7 +108,9 @@ impl Client {
     }
 
     fn head(&self, target: &str, key: &str) -> Result<Option<HeaderValue>, anyhow::Error> {
-        let url = self.base_url.join(target)
+        let url = self
+            .base_url
+            .join(target)
             .map_err(|e| anyhow::anyhow!("Error creating HEAD url: {e}"))?;
         debug!("HTTP HEAD to: {}", &url);
         let resp = self
@@ -113,7 +126,9 @@ impl Client {
     }
 
     fn post(&self, target: &str, json: &Map<String, Value>) -> Result<String, anyhow::Error> {
-        let url = self.base_url.join(target)
+        let url = self
+            .base_url
+            .join(target)
             .map_err(|e| anyhow::anyhow!("Error creating POST url: {e}"))?;
         debug!("--> HTTP POST to: {}", &url);
         let resp = self.http_client.post(url.as_str()).json(json).send()?;
@@ -128,7 +143,8 @@ impl Client {
             .map_err(|e| anyhow::anyhow!("Error creating POST url: {e}"))?;
         let mut out = fs::File::create(dest_path)
             .map_err(|e| anyhow::anyhow!("Failed to create an output file: {e}"))?;
-        let content = resp.bytes()
+        let content = resp
+            .bytes()
             .map_err(|e| anyhow::anyhow!("Failed to read download bytes: {e}"))?;
         io::copy(&mut content.as_bytes(), &mut out)
             .map_err(|e| anyhow::anyhow!("Failed to save the content to output file: {e}"))
@@ -136,13 +152,15 @@ impl Client {
 
     pub fn list_shares(&self) -> Result<Vec<Share>, anyhow::Error> {
         let shares = self.get("shares")?;
-        let parsed: ShareResponse = serde_json::from_str(&shares).map_err(|e| anyhow::anyhow!("Invalid list shares response: {e}"))?;
+        let parsed: ShareResponse = serde_json::from_str(&shares)
+            .map_err(|e| anyhow::anyhow!("Invalid list shares response: {e}"))?;
         return Ok(parsed.items.clone());
     }
 
     pub fn list_schemas(&self, share: &Share) -> Result<Vec<Schema>, anyhow::Error> {
         let schemas = self.get(&format!("shares/{}/schemas", share.name))?;
-        let parsed: SchemaResponse = serde_json::from_str(&schemas).map_err(|e| anyhow::anyhow!("Invalid list schemas response: {e}"))?;
+        let parsed: SchemaResponse = serde_json::from_str(&schemas)
+            .map_err(|e| anyhow::anyhow!("Invalid list schemas response: {e}"))?;
         return Ok(parsed.items.clone());
     }
 
@@ -151,13 +169,15 @@ impl Client {
             "shares/{}/schemas/{}/tables",
             schema.share, schema.name
         ))?;
-        let parsed: TableResponse = serde_json::from_str(&tables).map_err(|e| anyhow::anyhow!("Invalid list tables response: {e}"))?;
+        let parsed: TableResponse = serde_json::from_str(&tables)
+            .map_err(|e| anyhow::anyhow!("Invalid list tables response: {e}"))?;
         return Ok(parsed.items.clone());
     }
 
     pub fn list_all_tables(&self, share: &Share) -> Result<Vec<Table>, anyhow::Error> {
         let tables = self.get(&format!("shares/{}/all-tables", share.name))?;
-        let parsed: TableResponse = serde_json::from_str(&tables).map_err(|e| anyhow::anyhow!("Invalid list all tables response: {e}"))?;
+        let parsed: TableResponse = serde_json::from_str(&tables)
+            .map_err(|e| anyhow::anyhow!("Invalid list all tables response: {e}"))?;
         return Ok(parsed.items.clone());
     }
 
@@ -167,14 +187,20 @@ impl Client {
             table.share, table.schema, table.name
         ))?;
         let mut meta_lines = meta.lines();
-        let protocol: ProtocolResponse =
-            meta_lines.next().map(|lines| serde_json::from_str::<ProtocolResponse>(lines)
-                .map_err(|e| anyhow::anyhow!("Invalid protocol response - {lines}: {e}")))
-                .unwrap_or(Err(anyhow::anyhow!("Empty protocol response")))?;
-        let metadata: MetadataResponse =
-            meta_lines.next().map(|lines| serde_json::from_str::<MetadataResponse>(lines)
-                .map_err(|e| anyhow::anyhow!("Invalid metadata response - {lines}: {e}")))
-                .unwrap_or(Err(anyhow::anyhow!("Empty metadata response")))?;
+        let protocol: ProtocolResponse = meta_lines
+            .next()
+            .map(|lines| {
+                serde_json::from_str::<ProtocolResponse>(lines)
+                    .map_err(|e| anyhow::anyhow!("Invalid protocol response - {lines}: {e}"))
+            })
+            .unwrap_or(Err(anyhow::anyhow!("Empty protocol response")))?;
+        let metadata: MetadataResponse = meta_lines
+            .next()
+            .map(|lines| {
+                serde_json::from_str::<MetadataResponse>(lines)
+                    .map_err(|e| anyhow::anyhow!("Invalid metadata response - {lines}: {e}"))
+            })
+            .unwrap_or(Err(anyhow::anyhow!("Empty metadata response")))?;
         Ok(TableMetadata {
             protocol: protocol.protocol,
             metadata: metadata.metadata,
@@ -191,7 +217,10 @@ impl Client {
         );
         match version {
             Ok(Some(v)) => v
-                .to_str().ok().and_then(|value| value.parse::<i32>().ok()).unwrap_or(-1),
+                .to_str()
+                .ok()
+                .and_then(|value| value.parse::<i32>().ok())
+                .unwrap_or(-1),
             _ => -1,
         }
     }
@@ -207,8 +236,9 @@ impl Client {
                 "predicateHints".to_string(),
                 Value::Array(
                     predicate_hints
-                        .iter().map(|s| Value::String(s.to_string()))
-                        .collect::<Vec<_>>()
+                        .iter()
+                        .map(|s| Value::String(s.to_string()))
+                        .collect::<Vec<_>>(),
                 ),
             );
         }
@@ -219,10 +249,7 @@ impl Client {
             );
         }
         if let Some(version) = request.as_ref().and_then(|r| r.version) {
-            map.insert(
-                "version".to_string(),
-                Value::Number(Number::from(version)),
-            );
+            map.insert("version".to_string(), Value::Number(Number::from(version)));
         }
         let response = self.post(
             &format!(
@@ -232,17 +259,24 @@ impl Client {
             &map,
         )?;
         let mut lines = response.lines();
-        let protocol: ProtocolResponse =
-            lines.next().map(|lines| serde_json::from_str::<ProtocolResponse>(lines)
-                .map_err(|e| anyhow::anyhow!("Invalid protocol response - {lines}: {e}")))
-                .unwrap_or(Err(anyhow::anyhow!("Empty protocol response")))?;
-        let metadata: MetadataResponse =
-            lines.next().map(|lines| serde_json::from_str::<MetadataResponse>(lines)
-                .map_err(|e| anyhow::anyhow!("Invalid metadata response - {lines}: {e}")))
-                .unwrap_or(Err(anyhow::anyhow!("Empty metadata response")))?;
+        let protocol: ProtocolResponse = lines
+            .next()
+            .map(|lines| {
+                serde_json::from_str::<ProtocolResponse>(lines)
+                    .map_err(|e| anyhow::anyhow!("Invalid protocol response - {lines}: {e}"))
+            })
+            .unwrap_or(Err(anyhow::anyhow!("Empty protocol response")))?;
+        let metadata: MetadataResponse = lines
+            .next()
+            .map(|lines| {
+                serde_json::from_str::<MetadataResponse>(lines)
+                    .map_err(|e| anyhow::anyhow!("Invalid metadata response - {lines}: {e}"))
+            })
+            .unwrap_or(Err(anyhow::anyhow!("Empty metadata response")))?;
         let mut files: Vec<File> = Vec::new();
         for l in lines {
-            let file: FileResponse = serde_json::from_str(l).map_err(|e| anyhow::anyhow!("Invalid file info: {e}"))?;
+            let file: FileResponse =
+                serde_json::from_str(l).map_err(|e| anyhow::anyhow!("Invalid file info: {e}"))?;
             files.push(file.file.clone());
         }
         Ok(TableFiles {
@@ -254,11 +288,17 @@ impl Client {
         })
     }
 
-    fn download_files(&self, table_path: &PathBuf, table_files: &TableFiles) -> Result<Vec<PathBuf>, anyhow::Error> {
+    fn download_files(
+        &self,
+        table_path: &PathBuf,
+        table_files: &TableFiles,
+    ) -> Result<Vec<PathBuf>, anyhow::Error> {
         if Path::exists(&table_path) {
-            fs::remove_dir_all(&table_path).map_err(|e| anyhow::anyhow!("Error cleaning table path: {e}"))?;
+            fs::remove_dir_all(&table_path)
+                .map_err(|e| anyhow::anyhow!("Error cleaning table path: {e}"))?;
         }
-        fs::create_dir_all(&table_path).map_err(|e| anyhow::anyhow!("Error creating table path: {e}"))?;
+        fs::create_dir_all(&table_path)
+            .map_err(|e| anyhow::anyhow!("Error creating table path: {e}"))?;
         let mut file_paths: Vec<PathBuf> = Vec::new();
         let count = table_files.files.len();
         for (index, file) in table_files.files.clone().into_iter().enumerate() {
@@ -266,46 +306,68 @@ impl Client {
                 File::Parquet(ParquetFile { id, url, .. }) => {
                     let dst_path = &table_path.join(format!("{}.snappy.parquet", &id));
                     let bytes = self.download(url, &dst_path)?;
-                    debug!("Downloaded {}/{} {} ({} bytes)", index+1, count, dst_path.display(), bytes);
+                    debug!(
+                        "Downloaded {}/{} {} ({} bytes)",
+                        index + 1,
+                        count,
+                        dst_path.display(),
+                        bytes
+                    );
                     file_paths.push(dst_path.clone());
-                },
-		File::Delta( delta_file) => {
+                }
+                File::Delta(delta_file) => {
                     if let Some(url) = delta_file.get_url() {
-                        let dst_path = &table_path.join(format!("{}.snappy.parquet", &delta_file.id));
+                        let dst_path =
+                            &table_path.join(format!("{}.snappy.parquet", &delta_file.id));
                         let bytes = self.download(url, &dst_path)?;
-                        debug!("Downloaded {}/{} {} ({} bytes)", index+1, count, dst_path.display(), bytes);
+                        debug!(
+                            "Downloaded {}/{} {} ({} bytes)",
+                            index + 1,
+                            count,
+                            dst_path.display(),
+                            bytes
+                        );
                         file_paths.push(dst_path.clone());
                     }
-                }, 
+                }
             }
         }
         Ok(file_paths.clone())
     }
 
-    fn load_cached(&self, table_path: &PathBuf, table_files: &TableFiles) -> Result<Option<Vec<PathBuf>>, anyhow::Error>  {
+    fn load_cached(
+        &self,
+        table_path: &PathBuf,
+        table_files: &TableFiles,
+    ) -> Result<Option<Vec<PathBuf>>, anyhow::Error> {
         // Check if the files exist, load and compare the files.
         let metadata_path = &table_path.join(METADATA_FILE);
         if Path::exists(&metadata_path) {
-            let metadata_str = &fs::read_to_string(&metadata_path).map_err(|e| anyhow::anyhow!("Error reading file path {}: {}", metadata_path.display(), e))?;
-            let metadata: TableMetadata = serde_json::from_str(&metadata_str).map_err(|e| anyhow::anyhow!(
-                "Invalid configuration in {}: {}",
-                metadata_path.display(),
-                e
-            ))?;
+            let metadata_str = &fs::read_to_string(&metadata_path).map_err(|e| {
+                anyhow::anyhow!("Error reading file path {}: {}", metadata_path.display(), e)
+            })?;
+            let metadata: TableMetadata = serde_json::from_str(&metadata_str).map_err(|e| {
+                anyhow::anyhow!(
+                    "Invalid configuration in {}: {}",
+                    metadata_path.display(),
+                    e
+                )
+            })?;
             let mut download = metadata != table_files.metadata;
 
             if !download {
                 let mut file_paths: Vec<PathBuf> = Vec::new();
                 for file in &table_files.files {
                     let file_id = match file {
-                        File::Parquet(ParquetFile { id, ..}) => id,
-                        File::Delta(DeltaFile { id, .. }) => id
+                        File::Parquet(ParquetFile { id, .. }) => id,
+                        File::Delta(DeltaFile { id, .. }) => id,
                     };
                     let file_path = &table_path.join(format!("{}.snappy.parquet", &file_id));
                     if !Path::exists(&file_path) {
                         // File is missing, invalidate cache
                         download = true;
-                        fs::remove_dir_all(&table_path).map_err(|e| anyhow::anyhow!("Error invalidating cache: {e}"))?;
+                        fs::remove_dir_all(&table_path)
+                            .map_err(|e| anyhow::anyhow!("Error invalidating cache: {e}"))?;
                         break;
                     }
                     file_paths.push(file_path.clone());
@@ -318,7 +380,11 @@ impl Client {
         Ok(None)
     }
 
-    pub fn get_files(&mut self, table: &Table, request: Option<FilesRequest>) -> Result<Vec<PathBuf>, anyhow::Error> {
+    pub fn get_files(
+        &mut self,
+        table: &Table,
+        request: Option<FilesRequest>,
+    ) -> Result<Vec<PathBuf>, anyhow::Error> {
         let key = table.fully_qualified_name();
         let mut download = true;
         let table_path = Path::new(&self.data_root).join(table.fully_qualified_name());
@@ -350,10 +416,19 @@ impl Client {
                 },
             );
         }
-        Ok(self.cache.get(&key).ok_or(anyhow::anyhow!("Error reading {key} from cache"))?.file_paths.clone())
+        Ok(self
+            .cache
+            .get(&key)
+            .ok_or(anyhow::anyhow!("Error reading {key} from cache"))?
+            .file_paths
+            .clone())
     }
 
-    pub fn get_dataframe(&mut self, table: &Table, request: Option<FilesRequest>) -> Result<LazyFrame, anyhow::Error> {
+    pub fn get_dataframe(
+        &mut self,
+        table: &Table,
+        request: Option<FilesRequest>,
+    ) -> Result<LazyFrame, anyhow::Error> {
         self.get_files(&table, request)?;
         let table_path = Path::new(&self.data_root).join(table.fully_qualified_name());
         load_parquet_files_as_dataframe(&table_path)

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -193,29 +193,26 @@ impl Client {
     pub fn list_table_files(
         &self,
         table: &Table,
-        predicate_hints: Option<Vec<String>>,
-        limit_hint: Option<i32>,
-        version: Option<i32>,
+        request: Option<FilesRequest>,
     ) -> Result<TableFiles, anyhow::Error> {
         let mut map = Map::new();
-        if predicate_hints.is_some() {
+        if let Some(predicate_hints) = request.as_ref().and_then(|r| r.predicate_hints.as_ref()) {
             map.insert(
                 "predicateHints".to_string(),
                 Value::Array(
                     predicate_hints
-                        .map(|hints| hints.iter().map(|s| Value::String(s.to_string()))
-                        .collect::<Vec<_>>())
-                        .unwrap_or_default()
+                        .iter().map(|s| Value::String(s.to_string()))
+                        .collect::<Vec<_>>()
                 ),
             );
         }
-        if let Some(limit_hint) = limit_hint {
+        if let Some(limit_hint) = request.as_ref().and_then(|r| r.limit_hint) {
             map.insert(
                 "limitHint".to_string(),
                 Value::Number(Number::from(limit_hint)),
             );
         }
-        if let Some(version) = version {
+        if let Some(version) = request.as_ref().and_then(|r| r.version) {
             map.insert(
                 "version".to_string(),
                 Value::Number(Number::from(version)),
@@ -297,11 +294,11 @@ impl Client {
         Ok(None)
     }
 
-    pub fn get_files(&mut self, table: &Table) -> Result<Vec<PathBuf>, anyhow::Error> {
+    pub fn get_files(&mut self, table: &Table, request: Option<FilesRequest>) -> Result<Vec<PathBuf>, anyhow::Error> {
         let key = table.fully_qualified_name();
         let mut download = true;
         let table_path = Path::new(&self.data_root).join(table.fully_qualified_name());
-        let table_files = self.list_table_files(table, None, None, None)?;
+        let table_files = self.list_table_files(table, request)?;
         if let Some(cached) = self.cache.get(&key) {
             download = cached.table_files.metadata != table_files.metadata;
         } else if let Some(cached) = self.load_cached(&table_path, &table_files)? {
@@ -332,8 +329,8 @@ impl Client {
         Ok(self.cache.get(&key).ok_or(anyhow::anyhow!("Error reading {key} from cache"))?.file_paths.clone())
     }
 
-    pub fn get_dataframe(&mut self, table: &Table) -> PolarResult<LazyFrame> {
-        self.get_files(&table)?;
+    pub fn get_dataframe(&mut self, table: &Table, request: Option<FilesRequest>) -> PolarResult<LazyFrame> {
+        self.get_files(&table, request)?;
         let table_path = Path::new(&self.data_root).join(table.fully_qualified_name());
         load_parquet_files_as_dataframe(&table_path)
     }

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -260,19 +260,20 @@ impl Client {
         }
         fs::create_dir_all(&table_path).map_err(|e| anyhow::anyhow!("Error creating table path: {e}"))?;
         let mut file_paths: Vec<PathBuf> = Vec::new();
-        for file in table_files.files.clone() {
+        let count = table_files.files.len();
+        for (index, file) in table_files.files.clone().into_iter().enumerate() {
             match file {
                 File::Parquet(ParquetFile { id, url, .. }) => {
                     let dst_path = &table_path.join(format!("{}.snappy.parquet", &id));
                     let bytes = self.download(url, &dst_path)?;
-                    debug!("Downloaded {} ({} bytes)", dst_path.display(), bytes);
+                    debug!("Downloaded {}/{} {} ({} bytes)", index+1, count, dst_path.display(), bytes);
                     file_paths.push(dst_path.clone());
                 },
 		File::Delta( delta_file) => {
                     if let Some(url) = delta_file.get_url() {
                         let dst_path = &table_path.join(format!("{}.snappy.parquet", &delta_file.id));
                         let bytes = self.download(url, &dst_path)?;
-                        debug!("Downloaded {} ({} bytes)", dst_path.display(), bytes);
+                        debug!("Downloaded {}/{} {} ({} bytes)", index+1, count, dst_path.display(), bytes);
                         file_paths.push(dst_path.clone());
                     }
                 }, 

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -30,6 +30,7 @@ impl Client {
     pub fn new(
         provider_config: ProviderConfig,
         data_root: Option<String>,
+        capabilities: Option<HashMap<String, String>>
     ) -> Result<Self, anyhow::Error> {
         if provider_config.share_credentials_version > CREDENTIALS_VERSION {
             return Err(anyhow::anyhow!("'share_credentials_version' in the provider configuration is {}, which is newer than the \
@@ -39,7 +40,7 @@ impl Client {
         }
         let cache: HashMap<String, FileCache> = HashMap::new();
         Ok(Self {
-            http_client: Self::get_client(&provider_config)?,
+            http_client: Self::get_client(&provider_config, capabilities.unwrap_or_default())?,
             base_url: Self::build_base_url(&provider_config.endpoint)?,
             data_root: data_root.unwrap_or(
                 env::temp_dir()
@@ -53,7 +54,7 @@ impl Client {
         })
     }
 
-    fn get_client(config: &ProviderConfig) -> Result<reqwest::blocking::Client, anyhow::Error> {
+    fn get_client(config: &ProviderConfig, capabilities: HashMap<String, String>) -> Result<reqwest::blocking::Client, anyhow::Error> {
         let rust_version: &str = &format!("{}", rustc_version_runtime::version());
         let user_agent: &str = &format!("Delta-Sharing-Rust/{VERSION} Rust/{rust_version}");
         let bearer_token = &format!("Bearer {}", config.bearer_token);
@@ -67,6 +68,11 @@ impl Client {
             header::USER_AGENT,
             header::HeaderValue::from_str(user_agent)
                 .map_err(|e| anyhow::anyhow!("Error setting user agent header:{e}"))?,
+        );
+ 	headers.insert(
+            header::HeaderName::from_static("delta-sharing-capabilities"),
+            header::HeaderValue::from_str(&capabilities.iter().map(|(k,v)| format!("{k}={v}")).collect::<Vec<String>>().join(";"))
+                .map_err(|e| anyhow::anyhow!("Error setting delta-sharing-capabilities header:{e}"))?,
         );
         reqwest::blocking::Client::builder()
             .default_headers(headers)

--- a/src/blocking/mod.rs
+++ b/src/blocking/mod.rs
@@ -38,7 +38,7 @@
 //!              shares[0].name
 //!          );
 //!      } else {
-//!          let res = app.get_dataframe(&tables[0]).unwrap().collect().unwrap();
+//!          let res = app.get_dataframe(&tables[0], None).unwrap().collect().unwrap();
 //!          println!("Dataframe:\n {}", res);
 //!      }
 //!  }

--- a/src/blocking/mod.rs
+++ b/src/blocking/mod.rs
@@ -26,7 +26,7 @@
 //!      endpoint: "<your Delta Share endpoinit URL>".to_string(),
 //!      bearer_token: "<your Delta Share access token>".to_string(),
 //!  };
-//!  let mut app = Client::new(config, None).unwrap();
+//!  let mut app = Client::new(config, None, None).unwrap();
 //!  let shares = app.list_shares().unwrap();
 //!  if shares.len() == 0 {
 //!      println!("At least 1 Delta Share is required");

--- a/src/client.rs
+++ b/src/client.rs
@@ -278,19 +278,20 @@ impl Client {
         }
         fs::create_dir_all(&table_path).map_err(|e| anyhow::anyhow!("Error creating table path: {e}"))?;
         let mut file_paths: Vec<PathBuf> = Vec::new();
-        for file in table_files.files.clone() {
+        let count = table_files.files.len();
+        for (index, file) in table_files.files.clone().into_iter().enumerate() {
             match file {
                 File::Parquet(ParquetFile { id, url, .. }) => {
                     let dst_path = &table_path.join(format!("{}.snappy.parquet", &id));
                     let bytes = self.download(url, &dst_path).await?;
-                    debug!("Downloaded {} ({} bytes)", dst_path.display(), bytes);
+                    debug!("Downloaded {}/{} {} ({} bytes)", index+1, count, dst_path.display(), bytes);
                     file_paths.push(dst_path.clone());
                 },
                 File::Delta( delta_file) => {
                     if let Some(url) = delta_file.get_url() {
                         let dst_path = &table_path.join(format!("{}.snappy.parquet", &delta_file.id));
                         let bytes = self.download(url, &dst_path).await?;
-                        debug!("Downloaded {} ({} bytes)", dst_path.display(), bytes);
+                        debug!("Downloaded {}/{} {} ({} bytes)", index+1, count, dst_path.display(), bytes);
                         file_paths.push(dst_path.clone())
                     }
                 }, 

--- a/src/client.rs
+++ b/src/client.rs
@@ -32,10 +32,10 @@ impl Client {
         data_root: Option<String>,
     ) -> Result<Self, anyhow::Error> {
         if provider_config.share_credentials_version > CREDENTIALS_VERSION {
-            panic!("'share_credentials_version' in the provider configuration is {}, which is newer than the \
+            return Err(anyhow::anyhow!("'share_credentials_version' in the provider configuration is {}, which is newer than the \
                     version {} supported by the current release. Please upgrade to a newer release.", 
                     provider_config.share_credentials_version,
-                    CREDENTIALS_VERSION);
+                    CREDENTIALS_VERSION));
         }
         let cache: HashMap<String, FileCache> = HashMap::new();
         Ok(Self {
@@ -46,27 +46,30 @@ impl Client {
                     .as_path()
                     .join("delta_sharing")
                     .to_str()
-                    .unwrap()
+                    .ok_or(anyhow::anyhow!("Error selecting data root folder"))?
                     .to_string(),
             ),
             cache: cache,
         })
     }
 
-    fn get_client(config: &ProviderConfig) -> Result<reqwest::Client, reqwest::Error> {
+    fn get_client(config: &ProviderConfig) -> Result<reqwest::Client, anyhow::Error> {
         let rust_version: &str = &format!("{}", rustc_version_runtime::version());
         let user_agent: &str = &format!("Delta-Sharing-Rust/{VERSION} Rust/{rust_version}");
         let bearer_token = &format!("Bearer {}", config.bearer_token);
         let mut headers = header::HeaderMap::new();
         headers.insert(
             header::AUTHORIZATION,
-            header::HeaderValue::from_str(bearer_token).unwrap(),
+            header::HeaderValue::from_str(bearer_token)
+                .map_err(|e| anyhow::anyhow!("Error setting authorization header:{e}"))?,
         );
         headers.insert(
             header::USER_AGENT,
-            header::HeaderValue::from_str(user_agent).unwrap(),
+            header::HeaderValue::from_str(user_agent)
+                .map_err(|e| anyhow::anyhow!("Error setting user agent header:{e}"))?,
         );
         reqwest::Client::builder().default_headers(headers).build()
+            .map_err(|e| anyhow::anyhow!("Error building Http client: {e}"))
     }
 
     fn build_base_url(endpoint: &String) -> Result<Url, url::ParseError> {
@@ -75,8 +78,9 @@ impl Client {
         Url::parse(&root_path)
     }
 
-    async fn get(&self, target: &str) -> Result<String, reqwest::Error> {
-        let url = self.base_url.join(target).unwrap();
+    async fn get(&self, target: &str) -> Result<String, anyhow::Error> {
+        let url = self.base_url.join(target)
+            .map_err(|e| anyhow::anyhow!("Error creating GET url: {e}"))?;
         debug!("--> HTTP GET to: {}", &url);
         let resp = self.http_client.get(url.as_str()).send().await?;
         let resp_text = resp.text().await?;
@@ -84,19 +88,20 @@ impl Client {
         return Ok(resp_text);
     }
 
-    async fn head(&self, target: &str, key: &str) -> Option<HeaderValue> {
-        let url = self.base_url.join(target).unwrap();
+    async fn head(&self, target: &str, key: &str) -> Result<Option<HeaderValue>, anyhow::Error> {
+        let url = self.base_url.join(target)
+            .map_err(|e| anyhow::anyhow!("Error creating HEAD url: {e}"))?;
         debug!("HTTP HEAD to: {}", &url);
         let resp = self
             .http_client
             .head(url.as_str())
             .send()
             .await
-            .expect("Invalid request");
+            .map_err(|e| anyhow::anyhow!("Invalid HEAD request: {e}"))?;
         let version = resp.headers().get(key);
         match version {
-            Some(h) => Some(h.clone()),
-            None => None,
+            Some(h) => Ok(Some(h.clone())),
+            None => Ok(None),
         }
     }
 
@@ -104,8 +109,9 @@ impl Client {
         &self,
         target: &str,
         json: &Map<String, Value>,
-    ) -> Result<String, reqwest::Error> {
-        let url = self.base_url.join(target).unwrap();
+    ) -> Result<String, anyhow::Error> {
+        let url = self.base_url.join(target)
+            .map_err(|e| anyhow::anyhow!("Error creating POST url: {e}"))?;
         debug!("--> HTTP POST to: {}", &url);
         let resp = self
             .http_client
@@ -118,24 +124,27 @@ impl Client {
         return Ok(resp_text);
     }
 
-    async fn download(&self, url: String, dest_path: &Path) {
+    async fn download(&self, url: String, dest_path: &Path) -> Result<u64, anyhow::Error> {
         debug!("--> Download {} to {}", &url, dest_path.display());
-        let resp = reqwest::get(url).await.unwrap();
-        let mut out = fs::File::create(dest_path).expect("Failed to create an output file");
-        let content = resp.bytes().await.unwrap();
+        let resp = reqwest::get(url).await
+            .map_err(|e| anyhow::anyhow!("Error creating POST url: {e}"))?;
+        let mut out = fs::File::create(dest_path)
+            .map_err(|e| anyhow::anyhow!("Failed to create an output file: {e}"))?;
+        let content = resp.bytes().await
+            .map_err(|e| anyhow::anyhow!("Failed to read download bytes: {e}"))?;
         io::copy(&mut content.as_bytes(), &mut out)
-            .expect("Failed to save the content to output file");
+            .map_err(|e| anyhow::anyhow!("Failed to save the content to output file: {e}"))
     }
 
     pub async fn list_shares(&self) -> Result<Vec<Share>, anyhow::Error> {
         let shares = self.get("shares").await?;
-        let parsed: ShareResponse = serde_json::from_str(&shares).expect("Invalid response");
+        let parsed: ShareResponse = serde_json::from_str(&shares).map_err(|e| anyhow::anyhow!("Invalid list shares response: {e}"))?;
         return Ok(parsed.items.clone());
     }
 
     pub async fn list_schemas(&self, share: &Share) -> Result<Vec<Schema>, anyhow::Error> {
         let schemas = self.get(&format!("shares/{}/schemas", share.name)).await?;
-        let parsed: SchemaResponse = serde_json::from_str(&schemas).expect("Invalid response");
+        let parsed: SchemaResponse = serde_json::from_str(&schemas).map_err(|e| anyhow::anyhow!("Invalid list schemas response: {e}"))?;
         return Ok(parsed.items.clone());
     }
 
@@ -146,7 +155,7 @@ impl Client {
                 schema.share, schema.name
             ))
             .await?;
-        let parsed: TableResponse = serde_json::from_str(&tables).expect("Invalid response");
+        let parsed: TableResponse = serde_json::from_str(&tables).map_err(|e| anyhow::anyhow!("Invalid list tables response: {e}"))?;
         return Ok(parsed.items.clone());
     }
 
@@ -154,7 +163,7 @@ impl Client {
         let tables = self
             .get(&format!("shares/{}/all-tables", share.name))
             .await?;
-        let parsed: TableResponse = serde_json::from_str(&tables).expect("Invalid response");
+        let parsed: TableResponse = serde_json::from_str(&tables).map_err(|e| anyhow::anyhow!("Invalid list all tables response: {e}"))?;
         return Ok(parsed.items.clone());
     }
 
@@ -167,11 +176,13 @@ impl Client {
             .await?;
         let mut meta_lines = meta.lines();
         let protocol: ProtocolResponse =
-            serde_json::from_str(meta_lines.next().expect("Invalid response"))
-                .expect("Invalid protocol");
+            meta_lines.next().map(|lines| serde_json::from_str::<ProtocolResponse>(lines)
+                .map_err(|e| anyhow::anyhow!("Invalid protocol response - {lines}: {e}")))
+                .unwrap_or(Err(anyhow::anyhow!("Empty protocol response")))?;
         let metadata: MetadataResponse =
-            serde_json::from_str(meta_lines.next().expect("Invalid response"))
-                .expect("Invalid metadata");
+            meta_lines.next().map(|lines| serde_json::from_str::<MetadataResponse>(lines)
+                .map_err(|e| anyhow::anyhow!("Invalid metadata response - {lines}: {e}")))
+                .unwrap_or(Err(anyhow::anyhow!("Empty metadata response")))?;
         Ok(TableMetadata {
             protocol: protocol.protocol,
             metadata: metadata.metadata,
@@ -189,12 +200,9 @@ impl Client {
             )
             .await;
         match version {
-            Some(v) => v
-                .to_str()
-                .expect("Invalid version number")
-                .parse::<i32>()
-                .expect("Invalid version number"),
-            None => -1,
+            Ok(Some(v)) => v
+                .to_str().ok().and_then(|value| value.parse::<i32>().ok()).unwrap_or(-1),
+            _ => -1,
         }
     }
 
@@ -211,23 +219,22 @@ impl Client {
                 "predicateHints".to_string(),
                 Value::Array(
                     predicate_hints
-                        .unwrap()
-                        .iter()
-                        .map(|s| Value::String(s.to_string()))
-                        .collect::<Vec<_>>(),
+                        .map(|hints| hints.iter().map(|s| Value::String(s.to_string()))
+                        .collect::<Vec<_>>())
+                        .unwrap_or_default()
                 ),
             );
         }
-        if limit_hint.is_some() {
+        if let Some(limit_hint) = limit_hint {
             map.insert(
                 "limitHint".to_string(),
-                Value::Number(Number::from(limit_hint.unwrap())),
+                Value::Number(Number::from(limit_hint)),
             );
         }
-        if version.is_some() {
+        if let Some(version) = version {
             map.insert(
                 "version".to_string(),
-                Value::Number(Number::from(version.unwrap())),
+                Value::Number(Number::from(version)),
             );
         }
         let response = self
@@ -241,14 +248,16 @@ impl Client {
             .await?;
         let mut lines = response.lines();
         let protocol: ProtocolResponse =
-            serde_json::from_str(lines.next().expect("Invalid response"))
-                .expect("Invalid protocol");
+            lines.next().map(|lines| serde_json::from_str::<ProtocolResponse>(lines)
+                .map_err(|e| anyhow::anyhow!("Invalid protocol response - {lines}: {e}")))
+                .unwrap_or(Err(anyhow::anyhow!("Empty protocol response")))?;
         let metadata: MetadataResponse =
-            serde_json::from_str(lines.next().expect("Invalid response"))
-                .expect("Invalid metadata");
+            lines.next().map(|lines| serde_json::from_str::<MetadataResponse>(lines)
+                .map_err(|e| anyhow::anyhow!("Invalid metadata response - {lines}: {e}")))
+                .unwrap_or(Err(anyhow::anyhow!("Empty metadata response")))?;
         let mut files: Vec<File> = Vec::new();
         for l in lines {
-            let file: FileResponse = serde_json::from_str(l).expect("Invalid file info");
+            let file: FileResponse = serde_json::from_str(l).map_err(|e| anyhow::anyhow!("Invalid file info: {e}"))?;
             files.push(file.file.clone());
         }
         Ok(TableFiles {
@@ -260,33 +269,34 @@ impl Client {
         })
     }
 
-    async fn download_files(&self, table_path: &PathBuf, table_files: &TableFiles) -> Vec<PathBuf> {
+    async fn download_files(&self, table_path: &PathBuf, table_files: &TableFiles) -> Result<Vec<PathBuf>, anyhow::Error> {
         if Path::exists(&table_path) {
-            fs::remove_dir_all(&table_path).unwrap();
+            fs::remove_dir_all(&table_path).map_err(|e| anyhow::anyhow!("Error cleaning table path: {e}"))?;
         }
-        fs::create_dir_all(&table_path).unwrap();
+        fs::create_dir_all(&table_path).map_err(|e| anyhow::anyhow!("Error creating table path: {e}"))?;
         let mut file_paths: Vec<PathBuf> = Vec::new();
         for file in table_files.files.clone() {
             let dst_path = &table_path.join(format!("{}.snappy.parquet", &file.id));
-            self.download(file.url, &dst_path).await;
+            let _ = self.download(file.url, &dst_path).await;
             file_paths.push(dst_path.clone());
         }
-        file_paths.clone()
+        Ok(file_paths.clone())
     }
 
     async fn load_cached(
         &self,
         table_path: &PathBuf,
         table_files: &TableFiles,
-    ) -> Option<Vec<PathBuf>> {
+    ) -> Result<Option<Vec<PathBuf>>, anyhow::Error> {
         // Check if the files exist, load and compare the files.
         let metadata_path = &table_path.join(METADATA_FILE);
         if Path::exists(&metadata_path) {
-            let metadata_str = &fs::read_to_string(&metadata_path).unwrap();
-            let metadata: TableMetadata = serde_json::from_str(&metadata_str).expect(&format!(
-                "Invalid configuration in {}",
-                metadata_path.display()
-            ));
+            let metadata_str = &fs::read_to_string(&metadata_path).map_err(|e| anyhow::anyhow!("Error reading file path {}: {}", metadata_path.display(), e))?;
+            let metadata: TableMetadata = serde_json::from_str(&metadata_str).map_err(|e| anyhow::anyhow!(
+                "Invalid configuration in {}: {}",
+                metadata_path.display(),
+                e
+            ))?;
             let mut download = metadata != table_files.metadata;
 
             if !download {
@@ -296,17 +306,17 @@ impl Client {
                     if !Path::exists(&file_path) {
                         // File is missing, invalidate cache
                         download = true;
-                        fs::remove_dir(&table_path).unwrap();
+                        fs::remove_dir(&table_path).map_err(|e| anyhow::anyhow!("Error invalidating cache: {e}"))?;
                         break;
                     }
                     file_paths.push(file_path.clone());
                 }
                 if !download {
-                    return Some(file_paths.clone());
+                    return Ok(Some(file_paths.clone()));
                 }
             }
         }
-        None
+        Ok(None)
     }
 
     pub async fn get_files(&mut self, table: &Table) -> Result<Vec<PathBuf>, anyhow::Error> {
@@ -316,7 +326,7 @@ impl Client {
         let table_files = self.list_table_files(table, None, None, None).await?;
         if let Some(cached) = self.cache.get(&key) {
             download = cached.table_files.metadata != table_files.metadata;
-        } else if let Some(cached) = self.load_cached(&table_path, &table_files).await {
+        } else if let Some(cached) = self.load_cached(&table_path, &table_files).await? {
             download = false;
             self.cache.insert(
                 key.clone(),
@@ -328,7 +338,7 @@ impl Client {
         }
         if download {
             info!("--> Downloading data files to {}", &table_path.display());
-            let paths = self.download_files(&table_path, &table_files).await;
+            let paths = self.download_files(&table_path, &table_files).await?;
             serde_json::to_writer(
                 &fs::File::create(&table_path.join(METADATA_FILE))?,
                 &table_files.metadata,
@@ -341,7 +351,7 @@ impl Client {
                 },
             );
         }
-        Ok(self.cache.get(&key).unwrap().file_paths.clone())
+        Ok(self.cache.get(&key).ok_or(anyhow::anyhow!("Error reading {key} from cache"))?.file_paths.clone())
     }
 
     pub async fn get_dataframe(&mut self, table: &Table) -> PolarResult<LazyFrame> {
@@ -364,7 +374,6 @@ mod tests {
             endpoint: "https://sharing.delta.io/delta-sharing/".to_string(),
             bearer_token: "token".to_string(),
         };
-        let c = super::Client::new(config, None).await;
-        drop(c);
+        let _ = super::Client::new(config, None).await.unwrap();
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -326,7 +326,7 @@ impl Client {
                     if !Path::exists(&file_path) {
                         // File is missing, invalidate cache
                         download = true;
-                        fs::remove_dir(&table_path).map_err(|e| anyhow::anyhow!("Error invalidating cache: {e}"))?;
+                        fs::remove_dir_all(&table_path).map_err(|e| anyhow::anyhow!("Error invalidating cache: {e}"))?;
                         break;
                     }
                     file_paths.push(file_path.clone());

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,7 +2,7 @@ use crate::protocol::*;
 use crate::reader::*;
 use crate::utils::*;
 use parquet::data_type::AsBytes;
-use polars::prelude::{LazyFrame, Result as PolarResult};
+use polars::prelude::LazyFrame;
 use reqwest::{header, header::HeaderValue};
 use serde_json::{Map, Number, Value};
 use std::collections::HashMap;
@@ -374,10 +374,11 @@ impl Client {
         Ok(self.cache.get(&key).ok_or(anyhow::anyhow!("Error reading {key} from cache"))?.file_paths.clone())
     }
 
-    pub async fn get_dataframe(&mut self, table: &Table, request: Option<FilesRequest>) -> PolarResult<LazyFrame> {
+    pub async fn get_dataframe(&mut self, table: &Table, request: Option<FilesRequest>) -> Result<LazyFrame, anyhow::Error> {
         self.get_files(&table, request).await?;
         let table_path = Path::new(&self.data_root).join(table.fully_qualified_name());
         load_parquet_files_as_dataframe(&table_path)
+            .map_err(|e| anyhow::anyhow!("Error loading parquet files: {e}"))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@
 //!      endpoint: "<your Delta Share endpoinit URL>".to_string(),
 //!      bearer_token: "<your Delta Share access token>".to_string(),
 //!  };
-//!  let mut app = Client::new(config, None).await.unwrap();
+//!  let mut app = Client::new(config, None, None).await.unwrap();
 //!  let shares = app.list_shares().await.unwrap();
 //!  if shares.len() == 0 {
 //!      println!("At least 1 Delta Share is required");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@
 //!          );
 //!      } else {
 //!          let res = app
-//!              .get_dataframe(&tables[0])
+//!              .get_dataframe(&tables[0], None)
 //!              .await
 //!              .unwrap()
 //!              .collect()

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -42,20 +42,20 @@ pub struct DeltaProtocol {
     pub min_reader_version: i32,
     pub min_writer_version: i32,
     pub reader_features: Vec<String>,
-    pub writer_features: Vec<String>
+    pub writer_features: Vec<String>,
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum Protocol {
-    Parquet { 
+    Parquet {
         #[serde(rename = "minReaderVersion")]
-        min_reader_version: i32 
+        min_reader_version: i32,
     },
-    Delta { 
+    Delta {
         #[serde(rename = "deltaProtocol")]
-        delta_protocol: DeltaProtocol 
-    }
+        delta_protocol: DeltaProtocol,
+    },
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq, Serialize)]
@@ -81,14 +81,14 @@ pub struct ParquetMetadata {
 pub struct DeltaMetadata {
     pub size: usize,
     pub num_files: usize,
-    pub delta_metadata: ParquetMetadata
+    pub delta_metadata: ParquetMetadata,
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum Metadata {
     Parquet(ParquetMetadata),
-    Delta(DeltaMetadata)
+    Delta(DeltaMetadata),
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq, Serialize)]
@@ -120,7 +120,11 @@ pub struct DeltaFile {
 
 impl DeltaFile {
     pub fn get_url(&self) -> Option<String> {
-        if let Some(value) = self.delta_single_action.get("add").and_then(|add| add.get("path")) {
+        if let Some(value) = self
+            .delta_single_action
+            .get("add")
+            .and_then(|add| add.get("path"))
+        {
             return value.as_str().map(|v| v.to_string());
         } else {
             return None;
@@ -132,7 +136,7 @@ impl DeltaFile {
 #[serde(untagged)]
 pub enum File {
     Parquet(ParquetFile),
-    Delta(DeltaFile)
+    Delta(DeltaFile),
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq, Serialize)]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -120,7 +120,7 @@ pub struct DeltaFile {
 
 impl DeltaFile {
     pub fn get_url(&self) -> Option<String> {
-        if let Some(value) = self.delta_single_action.get("path") {
+        if let Some(value) = self.delta_single_action.get("add").and_then(|add| add.get("path")) {
             return value.as_str().map(|v| v.to_string());
         } else {
             return None;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -81,3 +81,9 @@ pub struct TableFiles {
     pub metadata: TableMetadata,
     pub files: Vec<File>,
 }
+
+pub struct FilesRequest {
+    pub predicate_hints: Option<Vec<String>>,
+    pub limit_hint: Option<i32>,
+    pub version: Option<i32>,
+}

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,7 +1,9 @@
 use polars::prelude::*;
 use std::path::PathBuf;
 
-pub fn load_parquet_files_as_dataframe(parquet_root_dir_path: &PathBuf) -> Result<LazyFrame, PolarsError> {
+pub fn load_parquet_files_as_dataframe(
+    parquet_root_dir_path: &PathBuf,
+) -> Result<LazyFrame, PolarsError> {
     let search_pattern = parquet_root_dir_path
         .join("*.parquet")
         .display()

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,12 +1,11 @@
-use polars::prelude::Result as PolarResult;
 use polars::prelude::*;
 use std::path::PathBuf;
 
-pub fn load_parquet_files_as_dataframe(parquet_root_dir_path: &PathBuf) -> PolarResult<LazyFrame> {
+pub fn load_parquet_files_as_dataframe(parquet_root_dir_path: &PathBuf) -> Result<LazyFrame, PolarsError> {
     let search_pattern = parquet_root_dir_path
         .join("*.parquet")
         .display()
         .to_string();
-    let res = LazyFrame::scan_parquet(search_pattern.into(), Default::default());
+    let res = LazyFrame::scan_parquet(search_pattern, Default::default());
     res
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -41,5 +41,3 @@ pub struct FileCache {
     pub table_files: TableFiles,
     pub file_paths: Vec<PathBuf>,
 }
-
-

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -36,13 +36,10 @@ pub struct FileResponse {
     pub file: File,
 }
 
-#[derive(Deserialize)]
-pub struct FileActionResponse {
-    pub file: File,
-}
-
 #[derive(Deserialize, PartialEq, Serialize)]
 pub struct FileCache {
     pub table_files: TableFiles,
     pub file_paths: Vec<PathBuf>,
 }
+
+

--- a/tests/blocking.rs
+++ b/tests/blocking.rs
@@ -74,7 +74,7 @@ fn get_dataframe() {
         "shares/{}/schemas/{}/tables/{}/query",
         table.share, table.schema, table.name
     );
-    let mut file: File =
+    let mut file: ParquetFile =
         serde_json::from_str(common::TEST_FILE_RESPONSE).expect("Invalid file info");
     let file_url_path = "/shares/test.parquet";
     file.url = format!("{}{}", &app.server.uri(), &file_url_path);

--- a/tests/blocking.rs
+++ b/tests/blocking.rs
@@ -21,7 +21,7 @@ fn create_blocking_test_app() -> BlockingTestApp {
         endpoint: server.uri(),
         bearer_token: Uuid::new_v4().to_string(),
     };
-    let client = Client::new(config, None).unwrap();
+    let client = Client::new(config, None, None).unwrap();
     let test_app = BlockingTestApp { client, server };
     test_app
 }

--- a/tests/blocking.rs
+++ b/tests/blocking.rs
@@ -117,11 +117,11 @@ fn get_dataframe() {
         .unwrap()
         .to_string();
 
-    let df = c.get_dataframe(&table).unwrap().collect().unwrap();
+    let df = c.get_dataframe(&table, None).unwrap().collect().unwrap();
     assert_eq!(df.shape(), (5, 3), "Dataframe shape mismatch");
 
     // Get the data again, this time it should be served from the local cache (enforced by Expections set on Mocks)
-    let df1 = c.get_dataframe(&table).unwrap().collect().unwrap();
+    let df1 = c.get_dataframe(&table, None).unwrap().collect().unwrap();
     assert_eq!(df1.shape(), (5, 3), "Dataframe shape mismatch");
     assert_eq!(
         df1.get_row(0).0[1],

--- a/tests/blocking.rs
+++ b/tests/blocking.rs
@@ -124,8 +124,8 @@ fn get_dataframe() {
     let df1 = c.get_dataframe(&table, None).unwrap().collect().unwrap();
     assert_eq!(df1.shape(), (5, 3), "Dataframe shape mismatch");
     assert_eq!(
-        df1.get_row(0).0[1],
-        polars::datatypes::AnyValue::Utf8("One"),
+        df1.get_row(0).unwrap().0[1],
+        polars::datatypes::AnyValue::String("One"),
         "Row value mismatch"
     );
 }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -193,7 +193,7 @@ async fn list_all_table_files() {
     let app = create_mocked_test_app(body, &url, method("POST")).await;
     let files = app
         .client
-        .list_table_files(&table, None, None, None)
+        .list_table_files(&table, None)
         .await
         .unwrap();
 
@@ -264,7 +264,7 @@ async fn get_files() {
 
     assert!(!Path::exists(&expected_path), "File should not exist");
 
-    let files = c.get_files(&table).await.unwrap();
+    let files = c.get_files(&table, None).await.unwrap();
 
     assert_eq!(files.len(), 1, "File count mismatch");
     assert_eq!(files[0], expected_path, "File path mismatch");
@@ -330,11 +330,11 @@ async fn get_dataframe() {
         .unwrap()
         .to_string();
 
-    let df = c.get_dataframe(&table).await.unwrap().collect().unwrap();
+    let df = c.get_dataframe(&table, None).await.unwrap().collect().unwrap();
     assert_eq!(df.shape(), (5, 3), "Dataframe shape mismatch");
 
     // Get the data again, this time it should be served from the local cache (enforced by Expections set on Mocks)
-    let df1 = c.get_dataframe(&table).await.unwrap().collect().unwrap();
+    let df1 = c.get_dataframe(&table, None).await.unwrap().collect().unwrap();
     assert_eq!(df1.shape(), (5, 3), "Dataframe shape mismatch");
     assert_eq!(
         df1.get_row(0).0[1],

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -348,8 +348,8 @@ async fn get_dataframe() {
     let df1 = c.get_dataframe(&table, None).await.unwrap().collect().unwrap();
     assert_eq!(df1.shape(), (5, 3), "Dataframe shape mismatch");
     assert_eq!(
-        df1.get_row(0).0[1],
-        polars::datatypes::AnyValue::Utf8("One"),
+        df1.get_row(0).unwrap().0[1],
+        polars::datatypes::AnyValue::String("One"),
         "Row value mismatch"
     );
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -30,7 +30,7 @@ pub async fn create_test_app() -> TestApp {
         endpoint: server.uri(),
         bearer_token: Uuid::new_v4().to_string(),
     };
-    let client = Client::new(config, None).await.unwrap();
+    let client = Client::new(config, None, None).await.unwrap();
     let app = TestApp { client, server };
     app
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -9,6 +9,7 @@ use wiremock::matchers::{path, MethodExactMatcher};
 use delta_sharing::protocol::*;
 use delta_sharing::Client;
 
+#[allow(dead_code)]
 pub struct TestApp {
     pub client: Client,
     pub server: MockServer,
@@ -18,6 +19,7 @@ pub const TEST_PROTOCOL_RESPONSE: &str = r#"{ "minReaderVersion": 1 }"#;
 pub const TEST_METADATA_RESPONSE: &str = r#"{ "id": "cf9c9342-b773-4c7b-a217-037d02ffe5d8", "format": { "provider": "parquet" }, "schemaString": "{\"type\":\"struct\",\"fields\":[{\"name\":\"int_field_1\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}},{\"name\":\"double_field_1\",\"type\":\"double\",\"nullable\":true,\"metadata\":{}}]}", "partitionColumns": [], "configuration": {"conf_1_name": "conf_1_value"} }"#;
 pub const TEST_FILE_RESPONSE: &str = r#"{ "url": "<url>", "id": "1", "partitionValues": {}, "size": 2350, "stats": "{\"numRecords\":1}" }"#;
 
+#[allow(dead_code)]
 pub async fn create_test_app() -> TestApp {
     let _ = env_logger::try_init();
 
@@ -33,6 +35,7 @@ pub async fn create_test_app() -> TestApp {
     app
 }
 
+#[allow(dead_code)]
 pub async fn create_mocked_test_app(
     body: &str,
     url: &str,


### PR DESCRIPTION
Hello and thank you for your work on delta-sharing-rust-client 
I have come to use it myself and it turns out that I required some improvements:

1) The library should never panic, otherwise requires the caller to catch unwind which is pretty tedious in async context and must not be considered real error handling anyways

2) The library should allow to specify on `get_dataframe` the same parameters that `list_table_files`, since right now it is defaulting them to None

3) The client must be able to pass the `delta-sharing-capabilities` header on each call

4) The Delta format (aside of Parquet format) must be supported as specified in protocol

Please review my PR and if you think it's worth to be merged I'll be happy to contribute.